### PR TITLE
fix: 레이아웃 불필요 스크롤 및 main 중복 구조 수정

### DIFF
--- a/src/components/layout/Main.tsx
+++ b/src/components/layout/Main.tsx
@@ -2,8 +2,8 @@ import React from 'react'
 
 export default async function Main({ children }: { children: React.ReactNode }) {
   return (
-    <main className="min-h-screen bg-gray-50">
-      <div className="mx-auto flex min-h-[calc(100%-129px)] max-w-7xl gap-5 px-5">{children}</div>
-    </main>
+    <div className="bg-gray-50">
+      <div className="mx-auto flex max-w-7xl gap-5 px-5">{children}</div>
+    </div>
   )
 }


### PR DESCRIPTION
## 변경 사항

- <main> 태그 중복 렌더링 제거 → 단일 <main> 구조로 정리
- 레이아웃 overflow 원인 제거하여 불필요한 스크롤 발생 이슈 해결

close #72