### PR TITLE
fix: 모바일에서 긴 댓글이 작성 영역에 가려지는 이슈 수정

### DIFF
--- a/src/features/(authenticated)/post/components/CommentSection.tsx
+++ b/src/features/(authenticated)/post/components/CommentSection.tsx
@@ -135,7 +135,7 @@ export function CommentSection({
     composer.mode === 'reply' ? '답글 작성' : composer.mode === 'edit' ? '댓글 수정' : '댓글 작성'
 
   return (
-    <section aria-label="댓글" className={['flex flex-col gap-4'].join(' ')}>
+    <section aria-label="댓글" className="flex flex-col gap-4 pb-[60px]">
       <h2 className="text-[16px] leading-[24px] font-normal text-[#101828] lg:text-[24px] lg:leading-[36px]">
         댓글 {totalCount}
       </h2>


### PR DESCRIPTION
## 변경 사항

- 모바일에서 댓글 리스트 하단 여백 부족으로 마지막 댓글이 댓글 작성 영역에 가려지는 문제 해결

close #100 