### PR TITLE
fix: 구글 로그인 팝업 COOP 헤더 적용

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -6,6 +6,23 @@ const nextConfig: NextConfig = {
       bodySizeLimit: '10mb',
     },
   },
+  async headers() {
+    const coop = {
+      key: 'Cross-Origin-Opener-Policy',
+      value: 'same-origin-allow-popups',
+    }
+
+    return [
+      {
+        source: '/signin/:path*',
+        headers: [coop],
+      },
+      {
+        source: '/signup/:path*',
+        headers: [coop],
+      },
+    ]
+  },
 }
 
 export default nextConfig


### PR DESCRIPTION
## 변경 사항

- next.config.ts에 Cross-Origin-Opener-Policy: same-origin-allow-popups 헤더 추가


close #109 