### PR TITLE
refactor: 리다이렉트 네비게이션을 replace 기반으로 통일

### DIFF
--- a/src/components/layout/header/ProfileMenu.tsx
+++ b/src/components/layout/header/ProfileMenu.tsx
@@ -57,7 +57,7 @@ export default function ProfileMenu() {
   const handleLogout = async () => {
     await fetch(`/api/auth/logout`, { method: 'DELETE', cache: 'no-store' })
     setOpen(false)
-    router.push('/signin')
+    router.replace('/signin')
     router.refresh()
   }
 

--- a/src/features/(authenticated)/admin/root/components/AdminPageButton.tsx
+++ b/src/features/(authenticated)/admin/root/components/AdminPageButton.tsx
@@ -57,7 +57,7 @@ export default function AdminPageButton({ tabs }: { tabs: TrackFields[] }) {
                       startTransition(async () => {
                         try {
                           await deleteTrack(tab.trackId as number)
-                          router.push(`/admin/operator`)
+                          router.replace(`/admin/operator`)
                         } catch (e) {
                           alert(e instanceof Error ? e.message : '삭제 실패')
                         }

--- a/src/features/(authenticated)/post/create/components/PostCreateHeader.tsx
+++ b/src/features/(authenticated)/post/create/components/PostCreateHeader.tsx
@@ -21,7 +21,7 @@ export function PostCreateHeader({
       router.back()
       return
     }
-    router.push(cancelFallbackHref)
+    router.replace(cancelFallbackHref)
   }
 
   return (

--- a/src/features/(authenticated)/post/create/components/PostDetailHeader.tsx
+++ b/src/features/(authenticated)/post/create/components/PostDetailHeader.tsx
@@ -26,7 +26,7 @@ export function PostDetailHeader({
       router.back()
       return
     }
-    router.push(fallbackHref)
+    router.replace(fallbackHref)
   }
 
   const iconBase = 'text-[rgba(55,56,60,0.61)]'

--- a/src/features/(authenticated)/post/create/components/PostForm.tsx
+++ b/src/features/(authenticated)/post/create/components/PostForm.tsx
@@ -64,8 +64,8 @@ export default function PostForm({ mode, action, initialValues, postId, formKey 
     qc.removeQueries({ queryKey: postKeys.listBase() })
     if (state.postId) {
       qc.removeQueries({ queryKey: postKeys.detail(state.postId) })
-      router.push(`/post/${state.postId}`)
-    } else router.push('/') // postId 못 받는 비정상 케이스 fallback
+      router.replace(`/post/${state.postId}`)
+    } else router.replace('/') // postId 못 받는 비정상 케이스 fallback
   }, [state.success, state.postId, qc, router])
 
   return (


### PR DESCRIPTION
## 변경 사항

- 전역적으로 리다이렉트 목적 네비게이션을 `router.push` → `router.replace`로 변경

close #135 