### PR TITLE
fix: 관리자 페이지 초기 진입 시 중복 로딩 방지

### DIFF
--- a/src/components/layout/header/HeaderElement.tsx
+++ b/src/components/layout/header/HeaderElement.tsx
@@ -22,7 +22,7 @@ export default function HeaderElement({ location }: { location: LocationType }) 
             <Button variant="cancel">관리자 모드 종료</Button>
           </Link>
         ) : (
-          <Link href="/admin">
+          <Link href="/admin/operator">
             <Button variant="warning" icon={<Shield size={16} />}>
               관리자 모드
             </Button>


### PR DESCRIPTION
## 변경 사항

- 관리자 진입 링크를 /admin → /admin/operator 로 변경하여 중간 리다이렉트(2-hop) 제거 및 로딩 2회 노출 방지

close #117 