### PR TITLE
fix: 배포 환경에서 게시글 상세 상대시간이 갱신되지 않는 이슈 해결

### DIFF
--- a/src/components/RelativeTime.tsx
+++ b/src/components/RelativeTime.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { toRelativeTimeLabel } from '@/utils/toRelativeTimeLabel'
+
+type RelativeTimeProps = {
+  dateTime: string
+  /** 서버에서 미리 계산한 라벨(초기 하이드레이션 mismatch 방지) */
+  initialLabel?: string
+  className?: string
+  /** 기본 1분마다 갱신 */
+  intervalMs?: number
+}
+
+export function RelativeTime({
+  dateTime,
+  initialLabel = '',
+  className,
+  intervalMs = 60_000,
+}: RelativeTimeProps) {
+  const [label, setLabel] = useState(initialLabel)
+
+  useEffect(() => {
+    if (!dateTime) return
+
+    const update = () => setLabel(toRelativeTimeLabel(dateTime))
+    update()
+
+    const id = window.setInterval(update, intervalMs)
+    return () => window.clearInterval(id)
+  }, [dateTime, intervalMs])
+
+  return (
+    <time dateTime={dateTime} className={className} suppressHydrationWarning>
+      {label}
+    </time>
+  )
+}


### PR DESCRIPTION
## 변경 사항

- RelativeTime Client 컴포넌트 추가로 상대시간 주기 갱신 처리
- PostDetailPage의 time 표시를 RelativeTime으로 교체(SSR initialLabel 전달)

close #162 