### PR TITLE
refactor: idToken url 노출 방지

### DIFF
--- a/src/app/(public)/signup/page.tsx
+++ b/src/app/(public)/signup/page.tsx
@@ -1,15 +1,13 @@
 import SignupForm from '@/features/(public)/signup/components/SignupForm'
-import { redirect } from 'next/navigation'
-import jwt from 'jsonwebtoken'
 import { getTrackList } from '@/features/(authenticated)/admin/track/services/getTrackList'
+import type { Metadata } from 'next'
 
-type SearchParams = { [key: string]: string | string[] | undefined }
+export const metadata: Metadata = {
+  title: '회원 가입 | Wanted Ground PotenUp',
+  description: '업계 트렌드와 이슈를 공유하고 정리하는 트렌드 게시판에 환영합니다.',
+}
 
-export default async function SignupPage(props: {
-  searchParams: SearchParams | Promise<SearchParams>
-}) {
-  const searchParams = await props.searchParams
-  const token = typeof searchParams.token === 'string' ? searchParams.token : ''
+export default async function SignupPage() {
   const trackData = await getTrackList(false)
   const selectTrack =
     trackData?.content?.length > 0
@@ -18,24 +16,6 @@ export default async function SignupPage(props: {
           value: String(track.trackId),
         }))
       : []
-
-  // token 아예 없으면 차단
-  if (!token || token.trim() === '') {
-    redirect('/signin')
-  }
-
-  // JWT 형식이 맞는지 확인
-  const isJwt = token.split('.').length === 3
-  if (!isJwt) {
-    redirect('/signin')
-  }
-
-  // 실제 JWT 검증
-  try {
-    jwt.decode(token)
-  } catch (_) {
-    redirect('/signin')
-  }
 
   return (
     <div className="mx-auto flex min-h-full max-w-sm flex-col justify-center px-4">
@@ -50,7 +30,7 @@ export default async function SignupPage(props: {
             입력해주세요.
           </p>
         </div>
-        <SignupForm token={token} provider="GOOGLE" selectTrack={selectTrack} />
+        <SignupForm provider="GOOGLE" selectTrack={selectTrack} />
 
         <p className="mx-auto mt-3 w-72 text-center text-xs leading-5 text-gray-400">
           회원가입을 진행하면 이용약관과 개인정보처리방침을 동의한 것으로 간주됩니다.

--- a/src/features/(public)/signin/useGoogleSignin.ts
+++ b/src/features/(public)/signin/useGoogleSignin.ts
@@ -9,9 +9,12 @@ import { SigninErrorTypes } from '@/features/(public)/signin/types/SigninError.t
 import { client } from '@/lib/api/client'
 import { USER_ERROR_MESSAGE } from '@/constants/error-message/user'
 import { HttpErrorTypes } from '@/types/HttpError.types'
+import { useIdTokenStore } from '@/store/idToken.store'
 
 export function useGoogleSignin() {
   const router = useRouter()
+  const setIdToken = useIdTokenStore((state) => state.setIdToken)
+
   const signinMutation = useMutation({
     mutationFn: async (code: string) => {
       const res = await client('/api/signin', {
@@ -35,7 +38,8 @@ export function useGoogleSignin() {
       if ((error.body as SigninErrorTypes).code === USER_ERROR_CODE.USER_NOT_FOUND) {
         const token = (error.body as SigninErrorTypes)?.idToken
         if (token) {
-          router.push(`/signup?token=${encodeURIComponent(token)}`)
+          setIdToken(token)
+          router.push(`/signup`)
         } else {
           const sp = new URLSearchParams({
             title: '유저 알림', //TODO: 성규님과 상의

--- a/src/features/(public)/signup/components/SignupForm.tsx
+++ b/src/features/(public)/signup/components/SignupForm.tsx
@@ -7,6 +7,7 @@ import { SignupFormTypes } from '@/features/(public)/signup/types/SignupForm.typ
 import FieldSelect from '@/components/form/FieldSelect'
 import { Loader2 } from 'lucide-react'
 import { useRouter } from 'next/navigation'
+import { useIdTokenStore } from '@/store/idToken.store'
 
 export const initialState: FormStateTypes<SignupFormTypes> = {
   values: {
@@ -21,15 +22,14 @@ export const initialState: FormStateTypes<SignupFormTypes> = {
 }
 
 export default function SignupForm({
-  token,
   provider,
   selectTrack,
 }: {
-  token: string
   provider: string
   selectTrack: { label: string; value: string }[]
 }) {
   const router = useRouter()
+  const idToken = useIdTokenStore((state) => state.idToken)
   const [state, formAction, isPending] = useActionState<FormStateTypes<SignupFormTypes>, FormData>(
     signupAction,
     initialState,
@@ -46,10 +46,16 @@ export default function SignupForm({
     }
   }, [state, router])
 
+  useEffect(() => {
+    if (!idToken) {
+      router.replace(`/signin`)
+    }
+  }, [idToken, router])
+
   return (
     <form action={formAction} className="space-y-4">
       <input type="hidden" name="provider" value={provider} />
-      <input type="hidden" name="token" value={token} />
+      <input type="hidden" name="token" value={idToken ?? ''} />
 
       <FieldInput
         name="name"

--- a/src/store/idToken.store.ts
+++ b/src/store/idToken.store.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand'
+
+type IdTokenState = {
+  idToken: string | null
+  setIdToken: (token: string | null) => void
+  clear: () => void
+}
+
+export const useIdTokenStore = create<IdTokenState>((set) => ({
+  idToken: null,
+  setIdToken: (token) => set({ idToken: token }),
+  clear: () => set({ idToken: null }),
+}))


### PR DESCRIPTION
## 변경 사항

- idToken을 url -> zustand 메모리로 관리 
- idToken 부재시 signup 페이지 가드

## 리뷰 필요

- zustand의 사용 규약에 맞는지
- 가드의 범위 맞는지

close #171 