### PR TITLE
fix: 배포 환경에서 게시글 상세 상대시간이 갱신되지 않는 이슈 해결

### DIFF
--- a/src/app/(authenticated)/post/[id]/(detail)/page.tsx
+++ b/src/app/(authenticated)/post/[id]/(detail)/page.tsx
@@ -14,12 +14,16 @@ import type { ReactionType } from '@/features/(authenticated)/post/types/Post.ty
 import { getPostDetailReaction } from '@/features/(authenticated)/post/apis/reaction.api'
 import { toggleReactionAction } from '@/features/(authenticated)/post/actions/toggleReactionAction'
 import { PostDetailHeader } from '@/features/(authenticated)/post/create/components/PostDetailHeader'
+import { RelativeTime } from '@/components/RelativeTime'
 
 export default async function PostDetailPage({ params }: { params: Promise<{ id: number }> }) {
   const { id } = await params
 
   const post = await getPostDetail(id)
   const user = await getUser()
+
+  const wroteAt = post?.wroteAt ?? ''
+  const wroteAtLabel = wroteAt ? toRelativeTimeLabel(wroteAt) : ''
 
   const isOwner = post && user?.userId === post.writerId
 
@@ -85,12 +89,11 @@ export default async function PostDetailPage({ params }: { params: Promise<{ id:
                   >
                     ·
                   </span>
-                  <time
+                  <RelativeTime
+                    dateTime={wroteAt}
+                    initialLabel={wroteAtLabel}
                     className="text-[14px] leading-[20px] text-[rgba(55,56,60,0.61)]"
-                    dateTime={post?.wroteAt}
-                  >
-                    {toRelativeTimeLabel(post?.wroteAt)}
-                  </time>
+                  />
                   <span className="inline-flex h-[22px] items-center justify-center rounded-lg bg-[#ECEEF2] px-2 text-[12px] leading-[16px] font-medium text-black">
                     {TOPIC_LABEL[post?.topic]}
                   </span>


### PR DESCRIPTION
## 변경 사항

- RelativeTime Client 컴포넌트 추가로 상대시간 주기 갱신 처리
- PostDetailPage의 time 표시를 RelativeTime으로 교체(SSR initialLabel 전달)

## 리뷰 포인트

- 재오픈된 #162 이슈 대응으로 동일 수정사항 기준 재PR입니다. (변경사항은 동일 / 재검증 목적)

close #162
