### PR TITLE
fix: 게시글/댓글 생성·수정 중 중복 제출 방지

### DIFF
--- a/src/features/(authenticated)/post/components/CommentItem.tsx
+++ b/src/features/(authenticated)/post/components/CommentItem.tsx
@@ -39,7 +39,6 @@ export function CommentItem({
     resetEditText,
   } = useCommentItemState(postId, comment.commentId)
 
-  // ✅ 중복 제출 방지 락(대댓글/수정 폼 각각)
   const replySubmitLockRef = useRef(false)
   const editSubmitLockRef = useRef(false)
 

--- a/src/features/(authenticated)/post/components/CommentItem.tsx
+++ b/src/features/(authenticated)/post/components/CommentItem.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useRef } from 'react'
 import { Avatar } from '@/components/ui/Avatar'
 import { Heart } from 'lucide-react'
 import type { Comment } from '../types/Comment.types'
@@ -37,6 +38,10 @@ export function CommentItem({
     setEditText,
     resetEditText,
   } = useCommentItemState(postId, comment.commentId)
+
+  // ✅ 중복 제출 방지 락(대댓글/수정 폼 각각)
+  const replySubmitLockRef = useRef(false)
+  const editSubmitLockRef = useRef(false)
 
   if (!actions) return null
 
@@ -84,12 +89,29 @@ export function CommentItem({
             </p>
           ) : (
             <form
+              onSubmitCapture={(e) => {
+                if (editSubmitLockRef.current) {
+                  e.preventDefault()
+                  e.stopPropagation()
+                  return
+                }
+                editSubmitLockRef.current = true
+              }}
               onSubmit={async (e) => {
                 e.preventDefault()
-                if (!canSubmitEdit) return
-                await onUpdate({ commentId: comment.commentId, content: editText.trim() })
-                resetEditText(comment.commentId)
-                closeAllEdit()
+
+                if (!canSubmitEdit) {
+                  editSubmitLockRef.current = false
+                  return
+                }
+
+                try {
+                  await onUpdate({ commentId: comment.commentId, content: editText.trim() })
+                  resetEditText(comment.commentId)
+                  closeAllEdit()
+                } finally {
+                  editSubmitLockRef.current = false
+                }
               }}
               className="hidden flex-col gap-2 lg:flex"
             >
@@ -110,13 +132,14 @@ export function CommentItem({
                   onClick={() => {
                     resetEditText(comment.commentId)
                     closeAllEdit()
+                    editSubmitLockRef.current = false
                   }}
                 >
                   취소
                 </button>
                 <button
                   type="submit"
-                  disabled={!canSubmitEdit}
+                  disabled={!canSubmitEdit || editSubmitLockRef.current}
                   className="h-8 rounded-lg bg-[#155DFC] px-4 text-[14px] leading-[20px] font-medium text-white disabled:opacity-50"
                 >
                   수정하기
@@ -226,6 +249,7 @@ export function CommentItem({
                       if (replyOpen) {
                         resetReplyText(comment.commentId)
                         closeAllReply()
+                        replySubmitLockRef.current = false
                         return
                       }
                       openOnlyReply(comment.commentId)
@@ -242,6 +266,7 @@ export function CommentItem({
                       if (editOpen) {
                         resetEditText(comment.commentId)
                         closeAllEdit()
+                        editSubmitLockRef.current = false
                         return
                       }
                       setEditText(comment.commentId, comment.content ?? '')
@@ -288,12 +313,29 @@ export function CommentItem({
               {!isDeleted && canReplyToThis && safeReplyOpen && (
                 <form
                   className="hidden pt-2 lg:block"
+                  onSubmitCapture={(e) => {
+                    if (replySubmitLockRef.current) {
+                      e.preventDefault()
+                      e.stopPropagation()
+                      return
+                    }
+                    replySubmitLockRef.current = true
+                  }}
                   onSubmit={async (e) => {
                     e.preventDefault()
-                    if (!canSubmitReply) return
-                    await onCreate({ parentId: comment.commentId, content: replyText.trim() })
-                    resetReplyText(comment.commentId)
-                    closeAllReply()
+
+                    if (!canSubmitReply) {
+                      replySubmitLockRef.current = false
+                      return
+                    }
+
+                    try {
+                      await onCreate({ parentId: comment.commentId, content: replyText.trim() })
+                      resetReplyText(comment.commentId)
+                      closeAllReply()
+                    } finally {
+                      replySubmitLockRef.current = false
+                    }
                   }}
                 >
                   <label className="sr-only" htmlFor={`reply-${comment.commentId}`}>
@@ -315,13 +357,14 @@ export function CommentItem({
                       onClick={() => {
                         resetReplyText(comment.commentId)
                         closeAllReply()
+                        replySubmitLockRef.current = false
                       }}
                     >
                       취소
                     </button>
                     <button
                       type="submit"
-                      disabled={!canSubmitReply}
+                      disabled={!canSubmitReply || replySubmitLockRef.current}
                       className="h-8 rounded-lg bg-[#155DFC] px-4 text-[14px] leading-[20px] font-medium text-white disabled:opacity-50"
                     >
                       답글 작성

--- a/src/features/(authenticated)/post/components/CommentSection.tsx
+++ b/src/features/(authenticated)/post/components/CommentSection.tsx
@@ -64,6 +64,10 @@ export function CommentSection({
   const isMobileSubmitting = createMut.isPending || updateMut.isPending
   const mobileCanSubmit = mobileText.trim().length > 0
 
+  // submit 중복 방지 락 (이벤트 레벨에서 선점)
+  const desktopSubmitLockRef = useRef(false)
+  const mobileSubmitLockRef = useRef(false)
+
   const openMobileCreate = () => {
     setComposer({ mode: 'create' })
     setMobileText('')
@@ -153,11 +157,24 @@ export function CommentSection({
         ))}
       </ol>
 
+      {/* 데스크탑 댓글 작성 */}
       <form
         className="hidden flex-col items-end gap-3 lg:flex"
+        onSubmitCapture={(e) => {
+          if (desktopSubmitLockRef.current) {
+            e.preventDefault()
+            e.stopPropagation()
+            return
+          }
+          desktopSubmitLockRef.current = true
+        }}
         onSubmit={async (e) => {
           e.preventDefault()
-          await submitDesktopRootComment()
+          try {
+            await submitDesktopRootComment()
+          } finally {
+            desktopSubmitLockRef.current = false
+          }
         }}
       >
         <label className="sr-only" htmlFor={`comment-${postId}`}>
@@ -194,15 +211,28 @@ export function CommentSection({
         </div>
       </form>
 
+      {/* 모바일 댓글 작성 */}
       <form
         className={[
           'fixed inset-x-0 bottom-0 z-30 lg:hidden',
           'border-t border-[#E5E7EB] bg-white',
           'px-4 pt-[17px] pb-[calc(16px+env(safe-area-inset-bottom))]',
         ].join(' ')}
+        onSubmitCapture={(e) => {
+          if (mobileSubmitLockRef.current) {
+            e.preventDefault()
+            e.stopPropagation()
+            return
+          }
+          mobileSubmitLockRef.current = true
+        }}
         onSubmit={async (e) => {
           e.preventDefault()
-          await submitMobile()
+          try {
+            await submitMobile()
+          } finally {
+            mobileSubmitLockRef.current = false
+          }
         }}
       >
         {mobileBannerText && (

--- a/src/features/(authenticated)/post/components/CommentSection.tsx
+++ b/src/features/(authenticated)/post/components/CommentSection.tsx
@@ -64,7 +64,6 @@ export function CommentSection({
   const isMobileSubmitting = createMut.isPending || updateMut.isPending
   const mobileCanSubmit = mobileText.trim().length > 0
 
-  // submit 중복 방지 락 (이벤트 레벨에서 선점)
   const desktopSubmitLockRef = useRef(false)
   const mobileSubmitLockRef = useRef(false)
 


### PR DESCRIPTION
## 변경 사항

- 게시글 생성/수정 중 중복 제출 방지
  - submit 시 ref 락 적용 + 폼 외부(헤더) submit 버튼을 DOM에서 즉시 disabled 처리
  - 성공 시 라우팅 완료(언마운트)까지 락 유지 / 실패 시 요청 종료 후 락 해제로 재시도 가능
  - FormData 누락 방지를 위해 input `disabled` 대신 `readOnly` 적용
- 댓글/대댓글 생성·수정 중 중복 제출 방지
  - 폼 submit 이벤트(`onSubmitCapture`)에서 ref 락으로 중복 요청 차단
  - 모바일/데스크탑 작성 폼 모두 동일 로직 적용

## 리뷰 필요

- 게시글: 헤더 submit 버튼 포함하여(더블클릭/엔터 제출) 초고속 연타 시 중복 생성이 재현되지 않는지 확인 부탁드립니다.
  - 실패 시 헤더 submit 버튼이 다시 활성화되어 재시도 가능한지도 확인 부탁드립니다.
- 댓글: 댓글/대댓글 작성/수정에서 동일 케이스로 중복 생성이 재현되지 않는지 확인 부탁드립니다.

close #168
