### PR TITLE
feat: 마이페이지 모바일 레이아웃 및 리다이렉트 대응 추가

### DIFF
--- a/src/app/(authenticated)/mypage/(with-tabs)/comment/page.tsx
+++ b/src/app/(authenticated)/mypage/(with-tabs)/comment/page.tsx
@@ -11,7 +11,7 @@ export const metadata: Metadata = {
   description: '내가 작성한 댓글을 확인하고 관리합니다.',
 }
 
-export default async function CommentPage() {
+export default async function MyCommentPage() {
   const qc = nqc()
 
   await qc.prefetchInfiniteQuery(getMyCommentsInfiniteQueryOption())

--- a/src/app/(authenticated)/mypage/(with-tabs)/layout.tsx
+++ b/src/app/(authenticated)/mypage/(with-tabs)/layout.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+import { MyPageTabs } from '@/features/(authenticated)/mypage/components/MyPageTabs'
+
+export default function WithTabsLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <MyPageTabs />
+      <div className="flex flex-col gap-0 lg:gap-4">{children}</div>
+    </>
+  )
+}

--- a/src/app/(authenticated)/mypage/(with-tabs)/like/page.tsx
+++ b/src/app/(authenticated)/mypage/(with-tabs)/like/page.tsx
@@ -11,7 +11,7 @@ export const metadata: Metadata = {
   description: '내가 좋아요한 게시글을 확인합니다.',
 }
 
-export default async function LikePage() {
+export default async function MyLikePage() {
   const qc = nqc()
 
   await qc.prefetchInfiniteQuery(getMyPostsInfiniteQueryOption({ topic: 'MY-POST-LIKED' }))

--- a/src/app/(authenticated)/mypage/(with-tabs)/post/page.tsx
+++ b/src/app/(authenticated)/mypage/(with-tabs)/post/page.tsx
@@ -1,33 +1,25 @@
 import React from 'react'
 import PageTitle from '@/components/ui/PageTitle'
 import { nqc } from '@/lib/query-client/queryClient'
-import type { Metadata } from 'next'
 import { dehydrate, HydrationBoundary } from '@tanstack/react-query'
 import { MyPostInfiniteList } from '@/features/(authenticated)/mypage/components/MyPostInfiniteList'
 import { getMyPostsInfiniteQueryOption } from '@/features/(authenticated)/mypage/queries/getMyPostsInfiniteQueryOption'
 
-export const metadata: Metadata = {
-  title: '내가 쓴 글 | 마이페이지 | Wanted Ground PotenUp',
-  description: '내가 쓴 글을 확인합니다.',
-}
-
-export default async function MyPage() {
+export default async function MyPostPage() {
   const qc = nqc()
-
   await qc.prefetchInfiniteQuery(getMyPostsInfiniteQueryOption({ topic: 'MY-POST' }))
 
   return (
-    <div className="">
+    <>
       <PageTitle title="내가 쓴 글" subTitle="커뮤니티에 작성한 글을 보여줍니다." />
-      <section className="flex flex-col gap-0 lg:gap-4">
-        <HydrationBoundary
-          state={dehydrate(qc, {
-            shouldDehydrateQuery: (q) => q.state.status === 'success',
-          })}
-        >
-          <MyPostInfiniteList topic="MY-POST" />
-        </HydrationBoundary>
-      </section>
-    </div>
+
+      <HydrationBoundary
+        state={dehydrate(qc, {
+          shouldDehydrateQuery: (q) => q.state.status === 'success',
+        })}
+      >
+        <MyPostInfiniteList topic="MY-POST" />
+      </HydrationBoundary>
+    </>
   )
 }

--- a/src/app/(authenticated)/mypage/layout.tsx
+++ b/src/app/(authenticated)/mypage/layout.tsx
@@ -2,13 +2,20 @@ import React from 'react'
 import AppShell from '@/components/layout/header/AppShell'
 import Main from '@/components/layout/Main'
 import { AsideMyPage } from '@/components/layout/aside/AsideMyPage'
+import { MyPageHeader } from '@/features/(authenticated)/mypage/components/MyPageHeader'
 
-export default async function MyPageLayout({ children }: { children: React.ReactNode }) {
+export default function MyPageLayout({ children }: { children: React.ReactNode }) {
   return (
     <AppShell location="mypage">
       <Main>
         <AsideMyPage />
-        <div className="w-full">{children}</div>
+        <section className="w-full bg-white lg:bg-transparent">
+          <div className="lg:hidden">
+            <MyPageHeader />
+          </div>
+
+          {children}
+        </section>
       </Main>
     </AppShell>
   )

--- a/src/app/(authenticated)/mypage/layout.tsx
+++ b/src/app/(authenticated)/mypage/layout.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import AppShell from '@/components/layout/header/AppShell'
 import Main from '@/components/layout/Main'
-import AsideMyPage from '@/components/layout/aside/AsideMyPage'
+import { AsideMyPage } from '@/components/layout/aside/AsideMyPage'
 
 export default async function MyPageLayout({ children }: { children: React.ReactNode }) {
   return (

--- a/src/app/(authenticated)/mypage/profile/page.tsx
+++ b/src/app/(authenticated)/mypage/profile/page.tsx
@@ -5,29 +5,87 @@ import { getUser } from '@/features/(authenticated)/users/apis/user.api'
 import { Avatar } from '@/components/ui/Avatar'
 import { MyPageProfileForm } from '@/features/(authenticated)/mypage/components/MyPageProfileForm'
 import { ChangeMyProfileImage } from '@/features/(authenticated)/mypage/components/ChangeMyProfileImage'
+import { Trash2 } from 'lucide-react'
 
 export const metadata: Metadata = {
   title: '프로필 설정 | 마이페이지 | Wanted Ground PotenUp',
   description: '내 프로필 정보를 확인하고 수정합니다.',
 }
 
-export default async function ProfilePage() {
+export default async function MyProfilePage() {
   const initialUser = await getUser()
 
   return (
-    <div>
-      <PageTitle title="프로필 설정" subTitle="나의 프로필 정보를 확인하고 수정할 수 있습니다." />
-      <section className="mt-5 max-w-xl">
-        <span className="relative inline-block">
-          <Avatar size="6xl" src={initialUser.profileImageUrl} alt="내 프로필" />
-          <ChangeMyProfileImage />
-        </span>
-        <MyPageProfileForm
-          name={initialUser.name}
-          email={initialUser.email}
-          track={String(initialUser.trackName)}
-        />
-      </section>
+    <div className="bg-white lg:bg-[#F9FAFB]">
+      <div className="hidden lg:block">
+        <PageTitle title="프로필 설정" subTitle="나의 프로필 정보를 확인하고 수정할 수 있습니다." />
+
+        <div className="mt-8 flex flex-col gap-8">
+          <div className="flex flex-col gap-8">
+            <div className="flex justify-start">
+              <span className="relative inline-block h-32 w-32">
+                <Avatar
+                  size="6xl"
+                  src={initialUser.profileImageUrl}
+                  alt="내 프로필"
+                  className="h-32 w-32 border-4 border-white bg-[#F3F4F6]"
+                />
+                <div className="absolute right-0 bottom-0">
+                  <ChangeMyProfileImage />
+                </div>
+              </span>
+            </div>
+
+            <div className="w-[573px]">
+              <MyPageProfileForm
+                name={initialUser.name}
+                email={initialUser.email}
+                track={String(initialUser.trackName)}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="min-h-[calc(100dvh-60px)] pt-(--header-h) lg:hidden">
+        <section className="mx-auto px-4">
+          <div className="flex justify-center">
+            <span className="relative inline-block">
+              <Avatar
+                size="6xl"
+                src={initialUser.profileImageUrl}
+                alt="내 프로필"
+                className="h-32 w-32 border-[3.7px] border-[#F9FAFB] shadow-[inset_0_2px_4px_rgba(0,0,0,0.05)]"
+              />
+              <div className="absolute right-0 bottom-0 translate-x-[6px] translate-y-[6px]">
+                <ChangeMyProfileImage />
+              </div>
+            </span>
+          </div>
+
+          <div className="mt-6">
+            <MyPageProfileForm
+              name={initialUser.name}
+              email={initialUser.email}
+              track={String(initialUser.trackName)}
+            />
+          </div>
+
+          <div className="mt-6">
+            <button
+              type="button"
+              className={[
+                'flex h-10 w-full items-center gap-2 rounded-[10px] pl-3',
+                'text-[14px] leading-6 text-[#AEB0B6]',
+                'focus:ring-2 focus:ring-[#AEB0B6]/20 focus:outline-none',
+              ].join(' ')}
+            >
+              <Trash2 size={16} className="shrink-0 text-[#AEB0B6]" />
+              <span className="relative top-[-0.5px]">회원 탈퇴</span>
+            </button>
+          </div>
+        </section>
+      </div>
     </div>
   )
 }

--- a/src/app/(authenticated)/mypage/profile/page.tsx
+++ b/src/app/(authenticated)/mypage/profile/page.tsx
@@ -3,8 +3,8 @@ import PageTitle from '@/components/ui/PageTitle'
 import type { Metadata } from 'next'
 import { getUser } from '@/features/(authenticated)/users/apis/user.api'
 import { Avatar } from '@/components/ui/Avatar'
-import MyPageProfileForm from '@/features/(authenticated)/mypage/components/MyPageProfileForm'
-import ChangeMyProfileImage from '@/features/(authenticated)/mypage/components/ChangeMyProfileImage'
+import { MyPageProfileForm } from '@/features/(authenticated)/mypage/components/MyPageProfileForm'
+import { ChangeMyProfileImage } from '@/features/(authenticated)/mypage/components/ChangeMyProfileImage'
 
 export const metadata: Metadata = {
   title: '프로필 설정 | 마이페이지 | Wanted Ground PotenUp',
@@ -22,7 +22,6 @@ export default async function ProfilePage() {
           <Avatar size="6xl" src={initialUser.profileImageUrl} alt="내 프로필" />
           <ChangeMyProfileImage />
         </span>
-
         <MyPageProfileForm
           name={initialUser.name}
           email={initialUser.email}

--- a/src/components/CommentCard.tsx
+++ b/src/components/CommentCard.tsx
@@ -10,41 +10,58 @@ type CommentCardProps = {
   isActive?: boolean
 }
 
-export default function CommentCard({ comment, isActive = false }: CommentCardProps) {
-  const createdAt = comment?.createdAt ?? ''
-  const createdAtLabel = formatDateDot(createdAt)
+export function CommentCard({ comment, isActive = false }: CommentCardProps) {
+  const createdAtLabel = formatDateDot(comment?.createdAt ?? '')
 
   const repliesCount = typeof comment.replies?.length === 'number' ? comment.replies.length : null
   const likeCount =
     typeof comment.commentReactionStats?.totalCount === 'number'
       ? comment.commentReactionStats.totalCount
-      : null
+      : 0
 
   return (
     <Link
       href={`/post/${comment.postId}`}
       className={clsx(
-        'flex w-full items-center justify-between',
-        'h-[82px] px-4',
-        'rounded-[10px] bg-white',
-        isActive ? 'border-2 border-[#155DFC]' : 'border border-[#E5E7EB]',
-        isActive ? '' : 'hover:border-[#155DFC] hover:bg-blue-50/20',
-        'md:max-w-[1045px]',
+        'block w-full',
+        'rounded-[12px] border border-[#F3F4F6] bg-white',
+        'px-[21px] pt-[21px] pb-[21px]',
+        'transition-colors',
+        !isActive &&
+          '[@media(hover:hover)]:hover:border-[#155DFC] [@media(hover:hover)]:hover:bg-blue-50/20',
+        !isActive && 'active:border-[#155DFC] active:bg-blue-50/20',
+        !isActive &&
+          'focus-visible:border-[#155DFC] focus-visible:bg-blue-50/20 focus-visible:outline-none',
+        'lg:flex lg:h-[82px] lg:items-center lg:justify-between',
+        'lg:rounded-[10px] lg:px-4 lg:py-0',
+        isActive ? 'lg:border-2 lg:border-[#155DFC]' : 'lg:border lg:border-[#E5E7EB]',
       )}
     >
-      <div className="min-w-0">
+      {/* 모바일: 좋아요 · 시간 + 본문 */}
+      <div className="flex flex-col gap-2 lg:hidden">
+        <div className="flex items-center gap-2 text-[14px] leading-[20px] text-[#989BA2]">
+          <span className="font-medium">좋아요 {likeCount}</span>
+          <span className="text-[#99A1AF]">·</span>
+          <span className="font-normal">{createdAtLabel}</span>
+        </div>
+
+        <p className="line-clamp-2 text-[16px] leading-[24px] text-[#1E2939]">{comment.content}</p>
+      </div>
+
+      {/* 데스크탑: 기존 구조 */}
+      <div className="hidden min-w-0 lg:block">
         <p className="truncate text-[16px] leading-[24px] font-medium text-[#000000]">
           {comment.content}
         </p>
-
         <p className="mt-1 text-[14px] leading-[20px] text-[rgba(55,56,60,0.61)]">
           {createdAtLabel}
         </p>
       </div>
 
-      <div className="flex shrink-0 items-center gap-4 text-[14px] leading-[20px] text-[#171719]">
+      {/* 데스크탑: 우측 메타 */}
+      <div className="hidden shrink-0 items-center gap-4 text-[14px] leading-[20px] text-[#171719] lg:flex">
         {repliesCount !== null && <span>대댓글 {repliesCount}</span>}
-        {likeCount !== null && <span>좋아요 {likeCount}</span>}
+        <span>좋아요 {likeCount}</span>
       </div>
     </Link>
   )

--- a/src/components/CommentCard.tsx
+++ b/src/components/CommentCard.tsx
@@ -1,40 +1,50 @@
 'use client'
 
-import React from 'react'
 import clsx from 'clsx'
-import { Comment } from '@/features/(authenticated)/mypage/types/getMyCommentsResponse'
 import Link from 'next/link'
-import { toRelativeTimeLabel } from '@/utils/toRelativeTimeLabel'
-import { RelativeTime } from '@/components/RelativeTime'
+import { Comment } from '@/features/(authenticated)/mypage/types/getMyCommentsResponse'
+import { formatDateDot } from '@/utils/formatDateDot'
 
-export default function CommentCard({ comment }: { comment: Comment }) {
+type CommentCardProps = {
+  comment: Comment
+  isActive?: boolean
+}
+
+export default function CommentCard({ comment, isActive = false }: CommentCardProps) {
   const createdAt = comment?.createdAt ?? ''
-  const createdAtLabel = createdAt ? toRelativeTimeLabel(createdAt) : ''
+  const createdAtLabel = formatDateDot(createdAt)
+
+  const repliesCount = typeof comment.replies?.length === 'number' ? comment.replies.length : null
+  const likeCount =
+    typeof comment.commentReactionStats?.totalCount === 'number'
+      ? comment.commentReactionStats.totalCount
+      : null
 
   return (
     <Link
       href={`/post/${comment.postId}`}
       className={clsx(
-        'block w-full border-b border-[rgba(0,0,0,0.06)] bg-white p-3',
-        'md:box-border md:max-w-[1045px] md:overflow-hidden md:rounded-[8px] md:border-b-0 md:bg-white',
-        'relative hover:bg-blue-50',
+        'flex w-full items-center justify-between',
+        'h-[82px] px-4',
+        'rounded-[10px] bg-white',
+        isActive ? 'border-2 border-[#155DFC]' : 'border border-[#E5E7EB]',
+        isActive ? '' : 'hover:border-[#155DFC] hover:bg-blue-50/20',
+        'md:max-w-[1045px]',
       )}
     >
-      <article className="flex flex-col gap-1">
-        <p className="font-medium">{comment.content}</p>
-        <RelativeTime
-          dateTime={createdAt}
-          initialLabel={createdAtLabel}
-          className="text-[14px] leading-[20px] text-[rgba(55,56,60,0.61)]"
-        />
-      </article>
-      <div className="absolute inset-y-0 right-4 flex items-center gap-3 text-xs">
-        <p>
-          {typeof comment.replies?.length === 'number' ? `대댓글 수 ${comment.replies.length}` : ''}
+      <div className="min-w-0">
+        <p className="truncate text-[16px] leading-[24px] font-medium text-[#000000]">
+          {comment.content}
         </p>
-        {typeof comment.commentReactionStats?.totalCount === 'number'
-          ? `좋아요 ${comment.commentReactionStats.totalCount}`
-          : ''}
+
+        <p className="mt-1 text-[14px] leading-[20px] text-[rgba(55,56,60,0.61)]">
+          {createdAtLabel}
+        </p>
+      </div>
+
+      <div className="flex shrink-0 items-center gap-4 text-[14px] leading-[20px] text-[#171719]">
+        {repliesCount !== null && <span>대댓글 {repliesCount}</span>}
+        {likeCount !== null && <span>좋아요 {likeCount}</span>}
       </div>
     </Link>
   )

--- a/src/components/layout/FloatingNav.tsx
+++ b/src/components/layout/FloatingNav.tsx
@@ -2,7 +2,7 @@
 
 import type { MouseEvent } from 'react'
 import Link from 'next/link'
-import { usePathname } from 'next/navigation'
+import { usePathname, useRouter } from 'next/navigation'
 import clsx from 'clsx'
 import { House, PencilLine, User } from 'lucide-react'
 import { TABS } from '@/features/(authenticated)/post/constants/tabs'
@@ -17,10 +17,11 @@ const items = [
 
 export default function FloatingNav() {
   const pathname = usePathname()
+  const router = useRouter()
 
   const handleMyPageClick = (e: MouseEvent<HTMLAnchorElement>) => {
     e.preventDefault()
-    alert('서비스 준비중입니다') // TODO: 토스트 교체
+    router.push('/mypage/profile')
   }
 
   const isHomeActive = pathname === '/' || HOME_PATHS.some((p) => pathname.startsWith(p))

--- a/src/components/layout/FloatingNav.tsx
+++ b/src/components/layout/FloatingNav.tsx
@@ -12,7 +12,7 @@ const HOME_PATHS = TABS.map((t) => t.href).filter(Boolean)
 const items = [
   { href: '/', label: '홈', icon: House },
   { href: '/post/create', label: '글쓰기', icon: PencilLine },
-  { href: '/mypage', label: '마이', icon: User, comingSoon: true },
+  { href: '/mypage/post', label: '마이', icon: User, comingSoon: true },
 ] as const
 
 export default function FloatingNav() {
@@ -21,7 +21,7 @@ export default function FloatingNav() {
 
   const handleMyPageClick = (e: MouseEvent<HTMLAnchorElement>) => {
     e.preventDefault()
-    router.push('/mypage/profile')
+    router.push('/mypage/post')
   }
 
   const isHomeActive = pathname === '/' || HOME_PATHS.some((p) => pathname.startsWith(p))

--- a/src/components/layout/aside/AsideMyPage.tsx
+++ b/src/components/layout/aside/AsideMyPage.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import clsx from 'clsx'
 import Link from 'next/link'
-import { ClipboardList, MessageCircle, Heart, UserCog, Trash2 } from 'lucide-react'
+import { MessageCircle, Heart, UserCog, Trash2, NotepadText } from 'lucide-react'
 import AsideMyPageSelector from '@/components/layout/aside/AsideMyPageSelector'
 import WithdrawMember from '@/features/(authenticated)/mypage/components/WithdrawMember'
 import { Avatar } from '@/components/ui/Avatar'
@@ -36,10 +36,10 @@ export async function AsideMyPage() {
               </AsideMyPageSelector>
             </Link>
 
-            <Link href="/mypage" className="w-full">
-              <AsideMyPageSelector pathname="/mypage">
-                <ClipboardList size={16} />
-                <span> 내가 쓴 글</span>
+            <Link href="/mypage/post" className="w-full">
+              <AsideMyPageSelector pathname="/mypage/post">
+                <NotepadText size={16} />
+                <span>내가 쓴 글</span>
               </AsideMyPageSelector>
             </Link>
 
@@ -53,7 +53,7 @@ export async function AsideMyPage() {
             <Link href="/mypage/like" className="w-full">
               <AsideMyPageSelector pathname="/mypage/like">
                 <Heart size={16} />
-                <span>내가 좋아요 한 글</span>
+                <span>좋아요 한 글</span>
               </AsideMyPageSelector>
             </Link>
 

--- a/src/components/layout/aside/AsideMyPage.tsx
+++ b/src/components/layout/aside/AsideMyPage.tsx
@@ -7,7 +7,7 @@ import WithdrawMember from '@/features/(authenticated)/mypage/components/Withdra
 import { Avatar } from '@/components/ui/Avatar'
 import { getUser } from '@/features/(authenticated)/users/apis/user.api'
 
-export default async function AsideMyPage() {
+export async function AsideMyPage() {
   const initialUser = await getUser()
 
   return (
@@ -23,12 +23,19 @@ export default async function AsideMyPage() {
             <Avatar size="lg" src={initialUser.profileImageUrl} alt="내 프로필" />
             <div className="flex flex-col items-start text-xs">
               <p className="text-base font-bold text-gray-900">{initialUser.name}</p>
-              <p className="mb-[1px] text-gray-900">{initialUser.email}</p>
+              <p className="mb-px text-gray-900">{initialUser.email}</p>
               <p className="text-gray-900">{initialUser.trackName}</p>
             </div>
           </div>
 
           <div className="flex w-full flex-col items-start gap-2">
+            <Link href="/mypage/profile" className="w-full">
+              <AsideMyPageSelector pathname="/mypage/profile">
+                <UserCog size={16} />
+                <span>프로필 설정</span>
+              </AsideMyPageSelector>
+            </Link>
+
             <Link href="/mypage" className="w-full">
               <AsideMyPageSelector pathname="/mypage">
                 <ClipboardList size={16} />
@@ -47,13 +54,6 @@ export default async function AsideMyPage() {
               <AsideMyPageSelector pathname="/mypage/like">
                 <Heart size={16} />
                 <span>내가 좋아요 한 글</span>
-              </AsideMyPageSelector>
-            </Link>
-
-            <Link href="/mypage/profile" className="w-full">
-              <AsideMyPageSelector pathname="/mypage/profile">
-                <UserCog size={16} />
-                <span>프로필 설정</span>
               </AsideMyPageSelector>
             </Link>
 

--- a/src/components/layout/header/ProfileMenu.tsx
+++ b/src/components/layout/header/ProfileMenu.tsx
@@ -116,7 +116,7 @@ export default function ProfileMenu({ user }: { user: User | null }) {
           }}
         >
           <Link
-            href="/mypage"
+            href="/mypage/profile"
             role="menuitem"
             tabIndex={0}
             data-menuitem
@@ -125,7 +125,7 @@ export default function ProfileMenu({ user }: { user: User | null }) {
           >
             <CircleUserRound size={16} className={iconClass} color="#4A5565" />
             마이페이지
-            {p.startsWith('/mypage') && <CheckMenu />}
+            {p.startsWith('/mypage/profile') && <CheckMenu />}
           </Link>
 
           <button

--- a/src/features/(authenticated)/mypage/actions/changeProfile.action.ts
+++ b/src/features/(authenticated)/mypage/actions/changeProfile.action.ts
@@ -11,7 +11,6 @@ export async function changeProfileAction(file: File): Promise<{ message: string
     await changeProfile(formData)
 
     revalidateTag('my-profile', 'max')
-    revalidatePath('/mypage')
     revalidatePath('/mypage/profile')
 
     return undefined

--- a/src/features/(authenticated)/mypage/components/ChangeMyProfileImage.tsx
+++ b/src/features/(authenticated)/mypage/components/ChangeMyProfileImage.tsx
@@ -4,7 +4,7 @@ import React, { useRef, useState } from 'react'
 import { Camera } from 'lucide-react'
 import { changeProfileAction } from '@/features/(authenticated)/mypage/actions/changeProfile.action'
 
-export default function ChangeMyProfileImage() {
+export function ChangeMyProfileImage() {
   const inputRef = useRef<HTMLInputElement | null>(null)
   const [failUpload, setFailUpload] = useState<string | undefined>()
 

--- a/src/features/(authenticated)/mypage/components/MyCommentInfiniteList.tsx
+++ b/src/features/(authenticated)/mypage/components/MyCommentInfiniteList.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef } from 'react'
 import { EmptyMyComment } from '@/features/(authenticated)/mypage/components/EmptyMyComment'
-import CommentCard from '@/components/CommentCard'
+import { CommentCard } from '@/components/CommentCard'
 import { useGetMyCommentsQuery } from '@/features/(authenticated)/mypage/queries/useGetMyComments'
 
 export function MyCommentInfiniteList({ size = 20 }: { size?: number }) {
@@ -43,7 +43,11 @@ export function MyCommentInfiniteList({ size = 20 }: { size?: number }) {
   if (isEmpty) return <EmptyMyComment />
 
   return (
-    <div className="flex flex-col gap-4">
+    <div
+      className={['flex flex-col gap-2 px-4 pt-2 pb-24', 'lg:gap-4 lg:px-0 lg:pt-0 lg:pb-0'].join(
+        ' ',
+      )}
+    >
       {items.map((comment) => (
         <CommentCard key={comment.commentId} comment={comment} />
       ))}

--- a/src/features/(authenticated)/mypage/components/MyCommentInfiniteList.tsx
+++ b/src/features/(authenticated)/mypage/components/MyCommentInfiniteList.tsx
@@ -8,7 +8,7 @@ import { useGetMyCommentsQuery } from '@/features/(authenticated)/mypage/queries
 export function MyCommentInfiniteList({ size = 20 }: { size?: number }) {
   const sentinelRef = useRef<HTMLDivElement | null>(null)
 
-  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, status, error } =
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, status } =
     useGetMyCommentsQuery(size)
 
   const items = data?.pages.flatMap((p) => p.contents) ?? []
@@ -43,7 +43,7 @@ export function MyCommentInfiniteList({ size = 20 }: { size?: number }) {
   if (isEmpty) return <EmptyMyComment />
 
   return (
-    <>
+    <div className="flex flex-col gap-4">
       {items.map((comment) => (
         <CommentCard key={comment.commentId} comment={comment} />
       ))}
@@ -55,6 +55,6 @@ export function MyCommentInfiniteList({ size = 20 }: { size?: number }) {
       {!isEmpty && isEnd && !isFetchingNextPage && (
         <p className="py-6 text-center text-sm text-[rgba(55,56,60,0.61)]">마지막 페이지입니다</p>
       )}
-    </>
+    </div>
   )
 }

--- a/src/features/(authenticated)/mypage/components/MyPageHeader.tsx
+++ b/src/features/(authenticated)/mypage/components/MyPageHeader.tsx
@@ -1,0 +1,55 @@
+'use client'
+
+import Link from 'next/link'
+import { useRouter, usePathname } from 'next/navigation'
+import { ArrowLeft } from 'lucide-react'
+
+export function MyPageHeader() {
+  const router = useRouter()
+  const pathname = usePathname()
+
+  const isProfilePage = pathname === '/mypage/profile'
+
+  const handleGoBack = () => {
+    if (typeof window !== 'undefined' && window.history.length > 1) {
+      router.back()
+      return
+    }
+    // 프로필 페이지에서 뒤로 fallback은 마이페이지로 보내는게 UX상 더 자연스러움
+    router.replace(isProfilePage ? '/mypage' : '/')
+  }
+
+  const iconBtn =
+    'flex h-[36px] w-[36px] items-center justify-center rounded-[8px] focus:ring-1 focus:ring-[#155DFC]/30 focus:outline-none'
+
+  const profileBtn =
+    'inline-flex h-[32px] items-center justify-center rounded-[8px] px-[12px] ' +
+    'bg-[#030213]/50 text-white text-[14px] leading-5 font-medium ' +
+    'focus:ring-1 focus:ring-[#155DFC]/30 focus:outline-none'
+
+  return (
+    <header className="fixed inset-x-0 top-0 z-30 h-(--header-h) border-b border-[#E5E7EB] bg-white">
+      <div className="relative mx-auto flex h-full w-full max-w-(--container-max) items-center px-4">
+        {/* 좌측: 뒤로 */}
+        <button type="button" onClick={handleGoBack} className={iconBtn} aria-label="뒤로가기">
+          <ArrowLeft size={16} className="text-[#0A0A0A]" />
+        </button>
+
+        {/* 가운데 타이틀 */}
+        <h1 className="absolute left-1/2 -translate-x-1/2 text-[16px] leading-6 font-medium text-[#101828]">
+          {isProfilePage ? '프로필 설정' : '마이페이지'}
+        </h1>
+
+        {/* 우측 */}
+        {isProfilePage ? (
+          // 레이아웃 흔들림 방지용(옵션): 버튼 자리 폭 유지
+          <div className="ml-auto h-[32px] w-[61px]" aria-hidden />
+        ) : (
+          <Link href="/mypage/profile" className={`ml-auto ${profileBtn}`}>
+            프로필
+          </Link>
+        )}
+      </div>
+    </header>
+  )
+}

--- a/src/features/(authenticated)/mypage/components/MyPageProfileForm.tsx
+++ b/src/features/(authenticated)/mypage/components/MyPageProfileForm.tsx
@@ -1,8 +1,7 @@
 'use client'
-import React from 'react'
 import FieldInput from '@/components/form/FieldInput'
 
-export default function MyPageProfileForm({
+export function MyPageProfileForm({
   name,
   email,
   track,

--- a/src/features/(authenticated)/mypage/components/MyPageTabs.tsx
+++ b/src/features/(authenticated)/mypage/components/MyPageTabs.tsx
@@ -1,0 +1,69 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import clsx from 'clsx'
+import { MessageSquare, Heart, NotepadText } from 'lucide-react'
+import React from 'react'
+
+type Tab = {
+  key: 'post' | 'comment' | 'like'
+  label: string
+  href: string
+  icon: React.ComponentType<{ className?: string }>
+}
+
+const TABS: Tab[] = [
+  { key: 'post', label: '내가 쓴 글', href: '/mypage/post', icon: NotepadText },
+  { key: 'comment', label: '댓글', href: '/mypage/comment', icon: MessageSquare },
+  { key: 'like', label: '좋아요', href: '/mypage/like', icon: Heart },
+]
+
+function isActive(pathname: string, href: string) {
+  return pathname.startsWith(href)
+}
+
+export function MyPageTabs() {
+  const pathname = usePathname()
+
+  return (
+    <div className={clsx('lg:hidden', 'sticky top-(--header-h) z-10', 'bg-white px-5 pt-4 pb-3')}>
+      <nav aria-label="My page tabs" className="w-full">
+        <div className="h-12 w-full rounded-[12px] bg-[rgba(112,115,124,0.08)] p-[3px]">
+          <div className="flex h-full items-center">
+            {TABS.map((tab) => {
+              const active = isActive(pathname, tab.href)
+              const Icon = tab.icon
+
+              return (
+                <Link
+                  key={tab.key}
+                  href={tab.href}
+                  aria-current={active ? 'page' : undefined}
+                  className={clsx(
+                    'relative flex h-[42px] flex-1 items-center justify-center rounded-[10px] px-[9px]',
+                    'transition-colors',
+                    'text-[17px] leading-[24px] font-medium',
+                    active
+                      ? 'bg-white text-[#171719] shadow-[0_0_4px_rgba(0,0,0,0.08)]'
+                      : 'text-[rgba(55,56,60,0.61)]',
+                  )}
+                >
+                  <span className="flex items-center justify-center gap-1">
+                    <Icon
+                      className={clsx(
+                        'h-4 w-4',
+                        active ? 'text-[#171719]' : 'text-[rgba(55,56,60,0.61)]',
+                      )}
+                    />
+                    <span className="flex items-center text-center">{tab.label}</span>
+                  </span>
+                </Link>
+              )
+            })}
+          </div>
+        </div>
+      </nav>
+    </div>
+  )
+}

--- a/src/features/(authenticated)/mypage/queries/getMyCommentsQueryOption.ts
+++ b/src/features/(authenticated)/mypage/queries/getMyCommentsQueryOption.ts
@@ -1,7 +1,6 @@
 import { getMyComments } from '@/features/(authenticated)/mypage/apis/getMyComment'
 import { DEFAULT_PAGE_SIZE } from '@/constants/pageSize'
-
-export type Cursor = number | null
+import type { GetMyCommentsResponse } from '@/features/(authenticated)/mypage/types/getMyCommentsResponse'
 
 export const myCommentKeys = {
   all: ['my-comment'] as const,
@@ -16,14 +15,17 @@ export function getMyCommentsInfiniteQueryOption(params: { size?: number } = {})
   return {
     queryKey: myCommentKeys.list({ size }),
     initialPageParam: 1,
-    queryFn: async ({ pageParam }: { pageParam: number }) => {
+
+    queryFn: async ({ pageParam }: { pageParam: number }): Promise<GetMyCommentsResponse> => {
       return getMyComments({
         page: pageParam,
         size,
       })
     },
-    getNextPageParam: (lastPage: any): Cursor => {
-      if (!lastPage.hasNext) return null
+
+    getNextPageParam: (lastPage: GetMyCommentsResponse) => {
+      if (!lastPage.hasNext) return undefined
+      if (typeof lastPage.nextPage !== 'number') return undefined
       return lastPage.nextPage
     },
   }

--- a/src/features/(authenticated)/mypage/queries/getMyPostsInfiniteQueryOption.ts
+++ b/src/features/(authenticated)/mypage/queries/getMyPostsInfiniteQueryOption.ts
@@ -1,10 +1,8 @@
 import { getMyPosts } from '@/features/(authenticated)/mypage/apis/getMyPosts'
 import { getMyLikes } from '@/features/(authenticated)/mypage/apis/getMyLike'
-import { GetPostsResponse } from '@/features/(authenticated)/post/types/Post.types'
 import { DEFAULT_PAGE_SIZE } from '@/constants/pageSize'
-import { MyPostTopic } from '@/features/(authenticated)/mypage/types/MyPostsTopic'
-
-export type Cursor = number | null
+import type { MyPostTopic } from '@/features/(authenticated)/mypage/types/MyPostsTopic'
+import { GetPostsResponse } from '../../post/types/Post.types'
 
 export const postKeys = {
   all: ['my-post'] as const,
@@ -24,13 +22,12 @@ export function getMyPostsInfiniteQueryOption(params: { topic?: MyPostTopic; siz
       // 내 글 목록
       if (topic === 'MY-POST') {
         return getMyPosts({ page: pageParam, size })
-      } else {
-        return getMyLikes({ page: pageParam, size })
       }
+      return getMyLikes({ page: pageParam, size })
     },
-    getNextPageParam: (lastPage: GetPostsResponse): Cursor => {
-      if (!lastPage.hasNext) return null
-      return lastPage.nextPage
+    getNextPageParam: (lastPage: GetPostsResponse) => {
+      if (!lastPage.hasNext) return undefined
+      return lastPage.nextPage ?? undefined
     },
   }
 }

--- a/src/utils/formatDateDot.ts
+++ b/src/utils/formatDateDot.ts
@@ -1,0 +1,11 @@
+export const formatDateDot = (input: string) => {
+  if (!input) return ''
+  const d = new Date(input)
+  if (Number.isNaN(d.getTime())) return ''
+
+  const yyyy = d.getFullYear()
+  const mm = String(d.getMonth() + 1).padStart(2, '0')
+  const dd = String(d.getDate()).padStart(2, '0')
+
+  return `${yyyy}.${mm}.${dd}`
+}


### PR DESCRIPTION
## 변경 사항

- **모바일 마이페이지 탭 뷰/레이아웃 적용**
  - 모바일 전용 `MyPageHeader`, `MyPageTabs`, `WithTabsLayout` 추가
  - `(with-tabs)` 그룹 라우팅 도입으로 모바일 탭 뷰 구조 정리
- **마이페이지 라우팅/진입 동작 정리**
  - `/mypage` 직하위 `page.tsx` 제거
  - 기본 진입 경로를 `/mypage/post`로 변경 (FloatingNav/ProfileMenu 포함)
  - 모바일 FloatingNav의 마이페이지 클릭 시 리다이렉트 분기 처리
- **UI 명세 반영 및 모바일 대응 보완**
  - '내가 쓴 댓글' 데스크탑 뷰 Figma 명세 반영
  - `CommentCard`, 프로필 페이지 모바일 레이아웃/오버플로우 보정
  - `AsideMyPage` 문구/아이콘 수정
- **공통 유틸/불필요 로직 정리**
  - `formatDateDot` 유틸 추가(YYYY.MM.DD)
  - `changeProfileAction`의 `revalidatePath('/mypage')` 제거(존재하지 않는 경로 호출 정리)
  - 마이페이지 관련 컴포넌트 `named export` 전환 및 사용처 반영
- **Infinite Query Option 타입 정리**
  - `getMyCommentsInfiniteQueryOption`/`getMyPostsInfiniteQueryOption`에서 `Cursor` 타입 제거
  - 반환 타입 정리 및 불필요 타입 의존성 제거

## 리뷰 필요

- **라우팅/리다이렉트**
  - `/mypage → /mypage/post` 기본 진입 + 탭 전환 시 경로 유지 확인
  - 로그인/비로그인 + 직접 URL 진입/뒤로가기 케이스에서 리다이렉트 정상 동작 확인
- **레이아웃**
  - `MyPageLayout` 변경(MyPageHeader 포함) 영향으로 데스크탑/모바일 깨짐 없는지
  - 프로필 설정 페이지 헤더 분기 정상 동작 여부

close #226