### PR TITLE
fix: 모달 후 뒷 배경이 스크롤이 되는 현상 방지

### DIFF
--- a/src/components/modal/shell/ModalShell.tsx
+++ b/src/components/modal/shell/ModalShell.tsx
@@ -2,7 +2,7 @@
 
 import React, { useCallback, useEffect } from 'react'
 import clsx from 'clsx'
-import { useRouter } from 'next/navigation'
+import { useLockBodyScroll } from '@/hooks/useScrollBox'
 
 export function ModalShell({
   children,
@@ -13,8 +13,10 @@ export function ModalShell({
   backdropClassName?: string
   returnTo?: string
 }) {
+  useLockBodyScroll()
+
   return (
-    <div className="fixed inset-0 z-[9999]">
+    <div className="fixed inset-0 z-[9999] overflow-hidden">
       <div className={clsx('absolute inset-0 bg-black/40', backdropClassName)} />
       {children}
     </div>

--- a/src/hooks/useScrollBox.ts
+++ b/src/hooks/useScrollBox.ts
@@ -1,0 +1,20 @@
+import { useEffect } from 'react'
+
+export function useLockBodyScroll() {
+  useEffect(() => {
+    const prevOverflow = document.body.style.overflow
+    const prevPaddingRight = document.body.style.paddingRight
+
+    const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth
+
+    document.body.style.overflow = 'hidden'
+    if (scrollbarWidth > 0) {
+      document.body.style.paddingRight = `${scrollbarWidth}px`
+    }
+
+    return () => {
+      document.body.style.overflow = prevOverflow
+      document.body.style.paddingRight = prevPaddingRight
+    }
+  }, [])
+}


### PR DESCRIPTION
## 변경 사항

- useHook 모달이 생성 되면 스크롤 방지

## 리뷰 필요

- 모달 생성 후 스크롤이 방지가 되는지

close #230 