### PR TITLE
fix: 프로필 이미지 원격 로딩 설정 반영

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,11 +3,18 @@ import type { NextConfig } from 'next'
 const nextConfig: NextConfig = {
   images: {
     remotePatterns: [
+      // 로컬 BE 프로필 이미지 서빙 경로
       {
         protocol: 'http',
         hostname: 'localhost',
         port: '8080',
         pathname: '/api/v1/users/profiles/**',
+      },
+      // 배포용 ngrok 이미지 서빙 경로
+      {
+        protocol: 'https',
+        hostname: 'epencephalic-iris-unswaying.ngrok-free.dev',
+        pathname: '/images/profiles/**',
       },
     ],
   },
@@ -23,14 +30,8 @@ const nextConfig: NextConfig = {
     }
 
     return [
-      {
-        source: '/signin/:path*',
-        headers: [coop],
-      },
-      {
-        source: '/signup/:path*',
-        headers: [coop],
-      },
+      { source: '/signin/:path*', headers: [coop] },
+      { source: '/signup/:path*', headers: [coop] },
     ]
   },
 }


### PR DESCRIPTION
## 변경 사항

- `next/image` 원격 이미지 로딩 허용을 위해 `images.remotePatterns` 설정 추가
- 로컬(`localhost:8080`) 및 개발용 ngrok 도메인 프로필 이미지 경로를 whitelist에 반영하여 이미지 렌더링 오류/차단 이슈 해결

## 리뷰 필요

- 로컬/개발 환경에서 프로필 이미지가 정상 노출되는지 확인 부탁드립니다.
- ngrok 도메인이 변경될 수 있어, 도메인 변경 시 remotePatterns 추가/갱신 필요 여부 확인 부탁드립니다

close #241