### PR TITLE
fix: 스터디 생성/신청 이후 모달이 닫히지 않는 이슈 해결 및 스터디 신청 연동

### DIFF
--- a/src/features/(authenticated)/post/components/ApplyStudyModal.tsx
+++ b/src/features/(authenticated)/post/components/ApplyStudyModal.tsx
@@ -20,8 +20,8 @@ export function ApplyStudyModal({
   const router = useRouter()
 
   const close = useCallback(() => {
-    router.back()
-    if (returnTo) setTimeout(() => router.replace(returnTo), 0)
+    router.replace(returnTo)
+    router.refresh()
   }, [router, returnTo])
 
   const [appeal, setAppeal] = useState('')
@@ -43,7 +43,7 @@ export function ApplyStudyModal({
         'relative w-[512px]',
         'rounded-[10px] border border-black/10 bg-white',
         'shadow-[0px_10px_15px_-3px_rgba(0,0,0,0.1),0px_4px_6px_-4px_rgba(0,0,0,0.1)]',
-        'flex flex-col', // ✅
+        'flex flex-col',
       ].join(' ')}
     >
       <form action={formAction} className="flex flex-col">
@@ -91,7 +91,6 @@ export function ApplyStudyModal({
               <p className="text-[12px] leading-4 text-red-600">{state.fieldErrors.appeal}</p>
             )}
 
-            {/* ✅ 에러 배너가 생겨도 footer랑 안 겹침 */}
             {state?.message && !state.success && (
               <div className="rounded-[8px] border border-red-200 bg-red-50 px-3 py-2 text-[13px] leading-5 text-red-700">
                 {state.message}

--- a/src/features/(authenticated)/post/components/CreateStudyModal.tsx
+++ b/src/features/(authenticated)/post/components/CreateStudyModal.tsx
@@ -34,11 +34,6 @@ export function CreateStudyModal({ returnTo = '/study', fixedTrack }: CreateStud
     success: false,
   })
 
-  useEffect(() => {
-    if (!state?.success) return
-    router.replace(returnTo)
-  }, [state?.success, router, returnTo])
-
   const [tags, setTags] = useState<string[]>([])
   const [budget, setBudget] = useState<StudyBudget | ''>('')
   const [form, setForm] = useState<FormState>({
@@ -50,9 +45,14 @@ export function CreateStudyModal({ returnTo = '/study', fixedTrack }: CreateStud
   })
 
   const close = useCallback(() => {
-    router.back()
-    if (returnTo) setTimeout(() => router.replace(returnTo), 0)
+    router.replace(returnTo)
+    router.refresh()
   }, [router, returnTo])
+
+  useEffect(() => {
+    if (!state?.success) return
+    close()
+  }, [state?.success, close])
 
   const capacityNum = useMemo(() => {
     const n = Number(form.capacity)
@@ -226,7 +226,7 @@ export function CreateStudyModal({ returnTo = '/study', fixedTrack }: CreateStud
           </div>
         </div>
 
-        {/* Footer (fixed, scroll 밖) */}
+        {/* Footer */}
         <div className="shrink-0 px-[25px] py-[16px]">
           <div className="flex justify-end gap-2">
             <button
@@ -466,7 +466,6 @@ function TagInput({
 
     const withHash = v.startsWith('#') ? v : `#${v}`
 
-    // 중복 방지(대소문자 무시)
     if (tags.some((t) => t.toLowerCase() === withHash.toLowerCase())) return
 
     onChange([...tags, withHash])

--- a/src/features/(authenticated)/post/components/StudyCard.tsx
+++ b/src/features/(authenticated)/post/components/StudyCard.tsx
@@ -62,9 +62,7 @@ export function StudyCard({
       return
     }
 
-    // TODO: 스터디 신청 모달/페이지 연동
-    // router.push(`/study/apply/${item.id}`)
-    notReady('스터디 신청')
+    router.push(`/study/apply/${item.id}`)
   }
 
   const handleEdit = () => {


### PR DESCRIPTION
## 변경 사항

- 스터디 **생성 성공 후 모달 닫힘 처리** 반영 (`router.replace` 기반) 및 목록 갱신/리다이렉트 플로우 정리
- 스터디 **신청 성공 후 모달 닫힘 처리** 반영 (`router.replace` 기반) 및 목록 갱신/리다이렉트 플로우 정리
- 스터디 **신청 모달/페이지 연동**: `ApplyStudyModalPage`에 `ApplyStudyModal` 연결, 모달 오픈/닫힘 및 라우팅 흐름 반영

## 리뷰 필요

- 생성/신청 성공 시 `router.replace`로 모달이 정상적으로 닫히고, **목록 갱신 이후 화면 전환**이 의도대로 동작하는지 확인 부탁드립니다
- 모달 라우팅(intercept) 사용 시 **뒤로가기/직접 URL 진입** 케이스에서 오픈/닫힘 플로우가 어색하지 않은지 확인 부탁드립니다

close #240