### PR TITLE
fix: 프로필 이미지 원격 로딩 설정 수정

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -14,7 +14,7 @@ const nextConfig: NextConfig = {
       {
         protocol: 'https',
         hostname: 'epencephalic-iris-unswaying.ngrok-free.dev',
-        pathname: '/images/profiles/**',
+        pathname: '/api/v1/images/profiles/**',
       },
     ],
   },


### PR DESCRIPTION
## 변경 사항

- `next/image` 원격 이미지 로딩 허용을 위해 `images.remotePatterns` 설정(프로필 이미지 경로) 정합성 수정
- 로컬(`localhost:8080`) 및 개발용 ngrok 도메인 프로필 이미지 경로를 whitelist에 반영하여 이미지 렌더링 차단/깨짐 이슈 개선

## 리뷰 필요

- 로컬/개발 환경에서 프로필 이미지 정상 노출 확인 부탁드립니다
- ngrok 도메인 변경 시 remotePatterns 갱신 필요 여부 확인 부탁드립니다

close #247
